### PR TITLE
Add support for Up (Australian Bank)

### DIFF
--- a/src/Bank.ts
+++ b/src/Bank.ts
@@ -7,7 +7,7 @@ export class BankError extends Data.TaggedError("BankError")<{
   readonly reason: "AccountNotFound" | "Unauthorized" | "Unknown"
   readonly bank: string
   readonly cause?: unknown
-}> {}
+}> { }
 
 export class Bank extends Context.Tag("Bank")<
   Bank,
@@ -16,7 +16,7 @@ export class Bank extends Context.Tag("Bank")<
       accountId: string,
     ) => Effect.Effect<ReadonlyArray<AccountTransaction>, BankError>
   }
->() {}
+>() { }
 
 export interface AccountTransaction {
   readonly dateTime: DateTime.DateTime
@@ -25,6 +25,7 @@ export interface AccountTransaction {
   readonly notes?: string
   readonly cleared?: boolean
   readonly category?: string
+  readonly transfer?: string
 }
 
 export const AccountTransactionOrder = Order.struct({

--- a/src/Bank.ts
+++ b/src/Bank.ts
@@ -7,7 +7,7 @@ export class BankError extends Data.TaggedError("BankError")<{
   readonly reason: "AccountNotFound" | "Unauthorized" | "Unknown"
   readonly bank: string
   readonly cause?: unknown
-}> { }
+}> {}
 
 export class Bank extends Context.Tag("Bank")<
   Bank,
@@ -16,7 +16,7 @@ export class Bank extends Context.Tag("Bank")<
       accountId: string,
     ) => Effect.Effect<ReadonlyArray<AccountTransaction>, BankError>
   }
->() { }
+>() {}
 
 export interface AccountTransaction {
   readonly dateTime: DateTime.DateTime

--- a/src/Bank.ts
+++ b/src/Bank.ts
@@ -24,6 +24,7 @@ export interface AccountTransaction {
   readonly payee: string
   readonly notes?: string
   readonly cleared?: boolean
+  readonly category?: string
 }
 
 export const AccountTransactionOrder = Order.struct({

--- a/src/Bank/Up.ts
+++ b/src/Bank/Up.ts
@@ -1,0 +1,160 @@
+import {
+  BigDecimal,
+  Chunk,
+  Config,
+  DateTime,
+  Effect,
+  flow,
+  identity,
+  Layer,
+  Option,
+  pipe,
+  Redacted,
+  Schedule,
+  Stream,
+} from "effect"
+import { configProviderNested } from "../internal/utils.js"
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "@effect/platform"
+import { NodeHttpClient } from "@effect/platform-node"
+import * as S from "@effect/schema/Schema"
+import { AccountTransaction, Bank } from "../Bank.js"
+
+const URL = "https://api.up.com.au/api/v1"
+
+export const UpBank = Effect.gen(function* () {
+  const userToken = yield* Config.redacted("userToken")
+  const client = (yield* HttpClient.HttpClient).pipe(
+    HttpClient.mapRequest(
+      flow(
+        HttpClientRequest.prependUrl(URL),
+        HttpClientRequest.bearerToken(Redacted.value(userToken)),
+        HttpClientRequest.acceptJson,
+      ),
+    ),
+    HttpClient.filterStatusOk,
+    HttpClient.retryTransient({
+      schedule: Schedule.exponential(500),
+      times: 5,
+    }),
+    HttpClient.transformResponse(Effect.orDie),
+  )
+
+  const stream = <S extends S.Schema.Any>(schema: S) => {
+    const Page = PaginatedResponse(schema)
+    return (request: HttpClientRequest.HttpClientRequest) => {
+      const getPage = (cursor: string | null) =>
+        pipe(
+          request,
+          cursor ? HttpClientRequest.setUrl(cursor.split(URL)[1]) : identity,
+          client.execute,
+          Effect.flatMap(HttpClientResponse.schemaBodyJson(Page)),
+          Effect.scoped,
+          Effect.orDie,
+        )
+
+      return Stream.paginateChunkEffect(null, (cursor: string | null) =>
+        getPage(cursor).pipe(
+          Effect.map(
+            ({ data, links }) =>
+              [data, Option.fromNullable(links.next)] as const,
+          ),
+        ),
+      )
+    }
+  }
+
+  const transactions = stream(Transaction)
+
+  const accountTransactions = (accountId: string) =>
+    Effect.gen(function* () {
+      const now = yield* DateTime.now
+      const lastMonth = now.pipe(DateTime.subtract({ days: 30 }))
+      const last30Days = yield* transactions(
+        HttpClientRequest.get(`/accounts/${accountId}/transactions`, {
+          urlParams: { 'filter[since]': DateTime.formatIso(lastMonth) },
+        }),
+      ).pipe(Stream.runCollect)
+      return last30Days.pipe(
+        Chunk.map((t) => t.accountTransaction()),
+        Chunk.toReadonlyArray,
+      )
+    })
+
+  return Bank.of({
+    exportAccount(accountId) {
+      return accountTransactions(accountId)
+    },
+  })
+}).pipe(
+  Effect.withConfigProvider(configProviderNested("up")),
+  Effect.annotateLogs({ service: "Bank/Up" }),
+  Layer.effect(Bank),
+  Layer.provide(NodeHttpClient.layerUndici),
+)
+
+class MoneyObject extends S.Class<MoneyObject>("MoneyObject")({
+  currencyCode: S.String,
+  value: S.String,
+  valueInBaseUnits: S.BigDecimalFromNumber
+}) { }
+
+
+class Transaction extends S.Class<Transaction>("Transaction")({
+  type: S.Literal("transactions"),
+  id: S.String,
+  attributes: S.Struct({
+    status: S.Literal("HELD", "SETTLED"),
+    rawText: S.NullOr(S.String),
+    description: S.String,
+    message: S.NullOr(S.String),
+    isCategorizable: S.Boolean,
+    holdInfo: S.NullOr(S.Struct({
+      amount: MoneyObject,
+      foreignAmount: S.NullOr(MoneyObject)
+    })),
+    roundUp: S.NullOr(S.Struct({
+      amount: MoneyObject,
+      boostAmount: MoneyObject
+    })),
+    cashBack: S.NullishOr(S.Struct({
+      amount: MoneyObject,
+      description: S.String
+    })),
+    amount: MoneyObject,
+    foreignAmount: S.NullOr(MoneyObject),
+    cardPurchaseMethod: S.NullOr(S.Struct({
+      method: S.Literal("BAR_CODE", "OCR", "CARD_PIN", "CARD_DETAILS", "CARD_ON_FILE", "ECOMMERCE", "MAGNETIC_STRIPE", "CONTACTLESS"),
+      cardNumberSuffix: S.NullOr(S.String)
+    })),
+    settledAt: S.NullOr(S.DateTimeZoned),
+    createdAt: S.DateTimeZoned,
+    transactionType: S.NullOr(S.String),
+    note: S.NullOr(S.Struct({ text: S.String })),
+    performingCustomer: S.NullOr(S.Struct({ displayName: S.String })),
+  })
+}) {
+  accountTransaction(): AccountTransaction {
+    return {
+      dateTime: this.attributes.createdAt,
+      amount: BigDecimal.unsafeDivide(this.attributes.amount.valueInBaseUnits, BigDecimal.fromNumber(100)),
+      payee: this.attributes.description,
+      notes: this.attributes.note?.text,
+      cleared: this.attributes.status === "SETTLED",
+    }
+  }
+}
+
+class Cursor extends S.Class<Cursor>("Cursor")({
+  prev: S.NullOr(S.String),
+  next: S.NullOr(S.String),
+}) { }
+
+const PaginatedResponse = <S extends S.Schema.Any>(schema: S) =>
+  S.Struct({
+    data: S.Chunk(schema),
+    links: Cursor,
+  })

--- a/src/Bank/Up.ts
+++ b/src/Bank/Up.ts
@@ -98,7 +98,7 @@ export const UpBankLive = Effect.gen(function* () {
 
 class MoneyObject extends Schema.Class<MoneyObject>("MoneyObject")({
   valueInBaseUnits: Schema.BigDecimalFromNumber,
-}) { }
+}) {}
 
 class Transaction extends Schema.Class<Transaction>("Transaction")({
   type: Schema.Literal("transactions"),
@@ -111,17 +111,21 @@ class Transaction extends Schema.Class<Transaction>("Transaction")({
   }),
   relationships: Schema.Struct({
     category: Schema.Struct({
-      data: Schema.NullOr(Schema.Struct({
-        type: Schema.Literal("categories"),
-        id: Schema.String,
-      }))
+      data: Schema.NullOr(
+        Schema.Struct({
+          type: Schema.Literal("categories"),
+          id: Schema.String,
+        }),
+      ),
     }),
     transferAccount: Schema.Struct({
-      data: Schema.NullOr(Schema.Struct({
-        type: Schema.Literal("accounts"),
-        id: Schema.String,
-      }))
-    })
+      data: Schema.NullOr(
+        Schema.Struct({
+          type: Schema.Literal("accounts"),
+          id: Schema.String,
+        }),
+      ),
+    }),
   }),
 }) {
   accountTransaction(): AccountTransaction {
@@ -135,7 +139,7 @@ class Transaction extends Schema.Class<Transaction>("Transaction")({
       notes: this.attributes.note?.text,
       cleared: this.attributes.status === "SETTLED",
       category: this.relationships.category.data?.id,
-      transfer: this.relationships.transferAccount.data?.id
+      transfer: this.relationships.transferAccount.data?.id,
     }
   }
 }
@@ -143,7 +147,7 @@ class Transaction extends Schema.Class<Transaction>("Transaction")({
 class Cursor extends Schema.Class<Cursor>("Cursor")({
   prev: Schema.NullOr(Schema.String),
   next: Schema.NullOr(Schema.String),
-}) { }
+}) {}
 
 const PaginatedResponse = <S extends Schema.Schema.Any>(schema: S) =>
   Schema.Struct({

--- a/src/Bank/Up.ts
+++ b/src/Bank/Up.ts
@@ -98,7 +98,7 @@ export const UpBankLive = Effect.gen(function* () {
 
 class MoneyObject extends Schema.Class<MoneyObject>("MoneyObject")({
   valueInBaseUnits: Schema.BigDecimalFromNumber,
-}) {}
+}) { }
 
 class Transaction extends Schema.Class<Transaction>("Transaction")({
   type: Schema.Literal("transactions"),
@@ -108,6 +108,14 @@ class Transaction extends Schema.Class<Transaction>("Transaction")({
     amount: MoneyObject,
     createdAt: Schema.DateTimeZoned,
     note: Schema.NullOr(Schema.Struct({ text: Schema.String })),
+  }),
+  relationships: Schema.Struct({
+    category: Schema.Struct({
+      data: Schema.NullOr(Schema.Struct({
+        type: Schema.Literal("categories"),
+        id: Schema.String,
+      }))
+    })
   }),
 }) {
   accountTransaction(): AccountTransaction {
@@ -127,7 +135,7 @@ class Transaction extends Schema.Class<Transaction>("Transaction")({
 class Cursor extends Schema.Class<Cursor>("Cursor")({
   prev: Schema.NullOr(Schema.String),
   next: Schema.NullOr(Schema.String),
-}) {}
+}) { }
 
 const PaginatedResponse = <S extends Schema.Schema.Any>(schema: S) =>
   Schema.Struct({

--- a/src/Bank/Up.ts
+++ b/src/Bank/Up.ts
@@ -115,6 +115,12 @@ class Transaction extends Schema.Class<Transaction>("Transaction")({
         type: Schema.Literal("categories"),
         id: Schema.String,
       }))
+    }),
+    transferAccount: Schema.Struct({
+      data: Schema.NullOr(Schema.Struct({
+        type: Schema.Literal("accounts"),
+        id: Schema.String,
+      }))
     })
   }),
 }) {
@@ -128,6 +134,8 @@ class Transaction extends Schema.Class<Transaction>("Transaction")({
       payee: this.attributes.description,
       notes: this.attributes.note?.text,
       cleared: this.attributes.status === "SETTLED",
+      category: this.relationships.category.data?.id,
+      transfer: this.relationships.transferAccount.data?.id
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,11 +4,11 @@ import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import * as Sync from "./Sync.js"
 import { Actual } from "./Actual.js"
 import { AkahuLive } from "./Bank/Akahu.js"
-import { UpBank } from "./Bank/Up.js"
+import { UpBankLive } from "./Bank/Up.js"
 
 const banks = {
   akahu: AkahuLive,
-  up: UpBank,
+  up: UpBankLive,
 } as const
 
 const bank = Options.choice("bank", Struct.keys(banks)).pipe(

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,12 @@ const categories = Options.keyValueMap("categories").pipe(
   ),
 )
 
-const run = Command.make("actualsync", { bank, accounts, categorize, categories }).pipe(
+const run = Command.make("actualsync", {
+  bank,
+  accounts,
+  categorize,
+  categories,
+}).pipe(
   Command.withHandler(({ accounts, categorize, categories }) =>
     Sync.run({
       accounts: [...accounts].map(([actualAccountId, bankAccountId]) => ({
@@ -44,8 +49,13 @@ const run = Command.make("actualsync", { bank, accounts, categorize, categories 
       })),
       categorize,
       categoryMapping: Option.getOrUndefined(
-        Option.map(categories,
-          (categoriesOption) => [...categoriesOption].map(([bankCategory, actualCategory]) => ({ bankCategory, actualCategory }))))
+        Option.map(categories, (categoriesOption) =>
+          [...categoriesOption].map(([bankCategory, actualCategory]) => ({
+            bankCategory,
+            actualCategory,
+          })),
+        ),
+      ),
     }),
   ),
   Command.provide(({ bank }) => Layer.mergeAll(banks[bank], Actual.Default)),

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,11 @@ import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import * as Sync from "./Sync.js"
 import { Actual } from "./Actual.js"
 import { AkahuLive } from "./Bank/Akahu.js"
+import { UpBank } from "./Bank/Up.js"
 
 const banks = {
   akahu: AkahuLive,
+  up: UpBank,
 } as const
 
 const bank = Options.choice("bank", Struct.keys(banks)).pipe(

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,14 +21,22 @@ const accounts = Options.keyValueMap("accounts").pipe(
   ),
 )
 
-const run = Command.make("actualsync", { bank, accounts }).pipe(
-  Command.withHandler(({ accounts }) =>
-    Sync.run(
-      [...accounts].map(([actualAccountId, bankAccountId]) => ({
+const categorize = Options.boolean("categorize").pipe(
+  Options.withAlias("c"),
+  Options.withDescription(
+    "If the bank supports categorization, try to categorize transactions",
+  ),
+)
+
+const run = Command.make("actualsync", { bank, accounts, categorize }).pipe(
+  Command.withHandler(({ accounts, categorize }) =>
+    Sync.run({
+      accounts: [...accounts].map(([actualAccountId, bankAccountId]) => ({
         actualAccountId,
         bankAccountId,
       })),
-    ),
+      categorize,
+    }),
   ),
   Command.provide(({ bank }) => Layer.mergeAll(banks[bank], Actual.Default)),
   Command.run({


### PR DESCRIPTION
Hi, the [Australian bank Up](up.com.au) provides [an API](https://developer.up.com.au/), and your lovely project structure made it a breeze for me to add support.

This works for me, and I plan on running this myself, would be great to have it upstreamed so I don't have to maintain a fork of the whole repository.

Thanks!

# TODO

- [x] Remove useless type definitions (I got a little crazy with it)
- [x] Add some way to import Ups fairly intelligent categorisation with a flag? 