### PR TITLE
Update readme to provide additional installation tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ actualsync --bank akahu \
   --accounts 'actual-account-id2=bank-account-id2'
 ```
 
+> [!IMPORTANT]  
+> The IDs used above are not the names of the accounts. The easiest way to find these IDs is to inspect the URL when viewing the account in question in Actual or Akahu.
+
 ### Docker
 
 You can also use the pre-built docker image: [`timsmart/actualbudget-sync:main`](https://hub.docker.com/r/timsmart/actualbudget-sync).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ npm install -g @tim-smart/actualbudget-sync
 > If the installation fails, check that the prerequisites specified in the
 [node-gyp](https://github.com/nodejs/node-gyp?tab=readme-ov-file#installation) 
 transitive dependency have been met. In general you'll need to have installed 
-Python and C++ build tools specific to your operating system. 
+Python and C++ build tools specific to your operating system.
+
 
 Here is a quick example of how to use the CLI:
 
@@ -52,6 +53,9 @@ actualsync --bank akahu \
 
 > [!IMPORTANT]  
 > The IDs used above are not the names of the accounts. The easiest way to find these IDs is to inspect the URL when viewing the account in question in Actual or Akahu.
+>
+> ![image](https://github.com/user-attachments/assets/55faf4d6-a3dd-402f-9449-9fffd4e5abb9)
+> ![image](https://github.com/user-attachments/assets/68c90f2c-92ee-40be-bdc2-ceed2acf8c22)
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,19 @@ Features:
 
 ## Installation
 
+### NPM
+
 You can install the CLI using npm:
 
 ```bash
 npm install -g @tim-smart/actualbudget-sync
 ```
+
+> [!NOTE]  
+> If the installation fails, check that the prerequisites specified in the
+[node-gyp](https://github.com/nodejs/node-gyp?tab=readme-ov-file#installation) 
+transitive dependency have been met. In general you'll need to have installed 
+Python and C++ build tools specific to your operating system. 
 
 Here is a quick example of how to use the CLI:
 


### PR DESCRIPTION
Here are some updates to the readme with some things I came up against while trying to run this for the first time.
- Transitive dependencies require certain prerequisites to be installed before NPM installation will work. The consumer of this tool shouldn't be expected to trawl the dependency tree to assess required prerequisites so nice to mention them here.
- I was getting obscure errors that ended up being related to the specified Actual and Akahu accounts not being found. I hadn't realised that we needed to specify the internal ID of these resources rather than the name.