### PR TITLE
Joint account deduplication

### DIFF
--- a/.changeset/fix-forward-transfer-dedup.md
+++ b/.changeset/fix-forward-transfer-dedup.md
@@ -1,0 +1,11 @@
+---
+"@tim-smart/actualbudget-sync": patch
+---
+
+fix: prevent duplicate counterpart transactions when syncing shared accounts
+
+When syncing shared Up Bank accounts (2UP), Forward/Cover transactions
+that were initially imported without a transfer payee (because the target
+account was not in scope) are now corrected to use the proper transfer
+payee before new transactions are imported. This prevents Actual Budget
+from auto-creating a duplicate counterpart transaction.

--- a/.changeset/fix-forward-transfer-dedup.md
+++ b/.changeset/fix-forward-transfer-dedup.md
@@ -2,10 +2,4 @@
 "@tim-smart/actualbudget-sync": patch
 ---
 
-fix: prevent duplicate counterpart transactions when syncing shared accounts
-
-When syncing shared Up Bank accounts (2UP), Forward/Cover transactions
-that were initially imported without a transfer payee (because the target
-account was not in scope) are now corrected to use the proper transfer
-payee before new transactions are imported. This prevents Actual Budget
-from auto-creating a duplicate counterpart transaction.
+fix: (UP) prevent duplicate counterpart transactions when syncing shared accounts

--- a/src/Sync.ts
+++ b/src/Sync.ts
@@ -132,10 +132,21 @@ export const run = Effect.fnUntraced(function* (options: {
     payees,
   })
 
-  for (const { transactions, ids, actualAccountId } of results) {
-    const alreadyImported = yield* actual.findImported(ids, actualAccountId)
-    let toImport: typeof transactions = []
-    const updates = Array.empty<Fiber.Fiber<unknown, ActualError>>()
+  // Pre-collect alreadyImported for all accounts before any updates or imports
+  const allAlreadyImported = yield* Effect.forEach(
+    results,
+    ({ ids, actualAccountId }) =>
+      actual
+        .findImported(ids, actualAccountId)
+        .pipe(Effect.map((imported) => ({ actualAccountId, imported }))),
+  )
+
+  // Pass 1: apply all updates (cleared + payee name + transfer payee correction)
+  const allUpdates = Array.empty<Fiber.Fiber<unknown, ActualError>>()
+  for (const { transactions, actualAccountId } of results) {
+    const { imported: alreadyImported } = allAlreadyImported.find(
+      (r) => r.actualAccountId === actualAccountId,
+    )!
     for (const transaction of transactions) {
       if (options.clearedOnly && !transaction.cleared) {
         continue
@@ -143,9 +154,11 @@ export const run = Effect.fnUntraced(function* (options: {
 
       const existing = alreadyImported.get(transaction.imported_id)
       if (!existing) {
-        toImport.push(transaction)
-      } else if (transaction.cleared && !existing.cleared) {
-        updates.push(
+        continue
+      }
+
+      if (transaction.cleared && !existing.cleared) {
+        allUpdates.push(
           yield* Effect.forkChild(
             actual.use((_) =>
               _.updateTransaction(existing.id, {
@@ -166,7 +179,7 @@ export const run = Effect.fnUntraced(function* (options: {
           transaction.payee_name !== existing.imported_payee &&
           existingPayee.name === existing.imported_payee
         ) {
-          updates.push(
+          allUpdates.push(
             yield* Effect.forkChild(
               actual.use((_) =>
                 _.updatePayee(existingPayee.id, {
@@ -177,9 +190,39 @@ export const run = Effect.fnUntraced(function* (options: {
           )
         }
       }
+
+      if ("payee" in transaction && existing.payee !== transaction.payee) {
+        allUpdates.push(
+          yield* Effect.forkChild(
+            actual.use((_) =>
+              _.updateTransaction(existing.id, {
+                payee: transaction.payee,
+              }),
+            ),
+          ),
+        )
+      }
+    }
+  }
+  yield* Fiber.awaitAll(allUpdates)
+
+  // Pass 2: collect new transactions and import them
+  for (const { transactions, actualAccountId } of results) {
+    const { imported: alreadyImported } = allAlreadyImported.find(
+      (r) => r.actualAccountId === actualAccountId,
+    )!
+    let toImport: typeof transactions = []
+    for (const transaction of transactions) {
+      if (options.clearedOnly && !transaction.cleared) {
+        continue
+      }
+
+      const existing = alreadyImported.get(transaction.imported_id)
+      if (!existing) {
+        toImport.push(transaction)
+      }
     }
     yield* actual.use((_) => _.importTransactions(actualAccountId, toImport))
-    yield* Fiber.awaitAll(updates)
   }
 })
 

--- a/src/Sync.ts
+++ b/src/Sync.ts
@@ -7,7 +7,7 @@ import {
   DateTime,
   Duration,
   Effect,
-  Fiber,
+  FiberSet,
   pipe,
 } from "effect"
 import {
@@ -15,7 +15,7 @@ import {
   AccountTransactionOrder,
   Bank,
 } from "./Bank.ts"
-import { Actual, type ActualError } from "./Actual.ts"
+import { Actual } from "./Actual.ts"
 
 const bigDecimal100 = BigDecimal.fromNumberUnsafe(100)
 const amountToInt = (amount: BigDecimal.BigDecimal) =>
@@ -78,7 +78,8 @@ export const runCollect = Effect.fnUntraced(function* (options: {
         transactions,
         // oxlint-disable-next-line unicorn/no-array-sort
         Array.sort(AccountTransactionOrder),
-        Array.map((transaction) => {
+        // oxlint-disable-next-line oxc/no-map-spread
+        Array.map((transaction): ImportTransaction => {
           const imported_id = importId(bankAccountId, transaction)
           const category = options.categorize && categoryId(transaction)
           const transferPayee =
@@ -109,6 +110,28 @@ export const runCollect = Effect.fnUntraced(function* (options: {
   )
 })
 
+type ImportTransaction =
+  | {
+      category?: string | undefined
+      amount: number
+      notes: string | undefined
+      cleared: boolean | undefined
+      payee: string
+      account: string
+      imported_id: string
+      date: string
+    }
+  | {
+      category?: string | undefined
+      amount: number
+      notes: string | undefined
+      cleared: boolean | undefined
+      payee_name: string
+      account: string
+      imported_id: string
+      date: string
+    }
+
 export const run = Effect.fnUntraced(function* (options: {
   readonly accounts: ReadonlyArray<{
     readonly bankAccountId: string
@@ -123,6 +146,7 @@ export const run = Effect.fnUntraced(function* (options: {
   readonly clearedOnly: boolean
 }) {
   const actual = yield* Actual
+  const fibers = yield* FiberSet.make()
   const categories = yield* actual.use((_) => _.getCategories())
   const payees = yield* actual.use((_) => _.getPayees())
 
@@ -132,21 +156,11 @@ export const run = Effect.fnUntraced(function* (options: {
     payees,
   })
 
-  // Pre-collect alreadyImported for all accounts before any updates or imports
-  const allAlreadyImported = yield* Effect.forEach(
-    results,
-    ({ ids, actualAccountId }) =>
-      actual
-        .findImported(ids, actualAccountId)
-        .pipe(Effect.map((imported) => ({ actualAccountId, imported }))),
-  )
+  const newTransactions = new Map<string, Array<ImportTransaction>>()
 
-  // Pass 1: apply all updates (cleared + payee name + transfer payee correction)
-  const allUpdates = Array.empty<Fiber.Fiber<unknown, ActualError>>()
-  for (const { transactions, actualAccountId } of results) {
-    const { imported: alreadyImported } = allAlreadyImported.find(
-      (r) => r.actualAccountId === actualAccountId,
-    )!
+  for (const { transactions, ids, actualAccountId } of results) {
+    const alreadyImported = yield* actual.findImported(ids, actualAccountId)
+
     for (const transaction of transactions) {
       if (options.clearedOnly && !transaction.cleared) {
         continue
@@ -154,21 +168,26 @@ export const run = Effect.fnUntraced(function* (options: {
 
       const existing = alreadyImported.get(transaction.imported_id)
       if (!existing) {
+        let arr = newTransactions.get(actualAccountId)
+        if (!arr) {
+          arr = []
+          newTransactions.set(actualAccountId, arr)
+        }
+        arr.push(transaction)
         continue
       }
 
       if (transaction.cleared && !existing.cleared) {
-        allUpdates.push(
-          yield* Effect.forkChild(
-            actual.use((_) =>
-              _.updateTransaction(existing.id, {
-                cleared: true,
-                amount: transaction.amount,
-                ...(!existing.category && transaction.category
-                  ? { category: transaction.category }
-                  : {}),
-              }),
-            ),
+        yield* FiberSet.run(
+          fibers,
+          actual.use((_) =>
+            _.updateTransaction(existing.id, {
+              cleared: true,
+              amount: transaction.amount,
+              ...(!existing.category && transaction.category
+                ? { category: transaction.category }
+                : {}),
+            }),
           ),
         )
 
@@ -179,52 +198,39 @@ export const run = Effect.fnUntraced(function* (options: {
           transaction.payee_name !== existing.imported_payee &&
           existingPayee.name === existing.imported_payee
         ) {
-          allUpdates.push(
-            yield* Effect.forkChild(
-              actual.use((_) =>
-                _.updatePayee(existingPayee.id, {
-                  name: transaction.payee_name,
-                }),
-              ),
+          yield* FiberSet.run(
+            fibers,
+            actual.use((_) =>
+              _.updatePayee(existingPayee.id, {
+                name: transaction.payee_name,
+              }),
             ),
           )
         }
       }
 
       if ("payee" in transaction && existing.payee !== transaction.payee) {
-        allUpdates.push(
-          yield* Effect.forkChild(
-            actual.use((_) =>
-              _.updateTransaction(existing.id, {
-                payee: transaction.payee,
-              }),
-            ),
+        yield* FiberSet.run(
+          fibers,
+          actual.use((_) =>
+            _.updateTransaction(existing.id, {
+              payee: transaction.payee,
+            }),
           ),
         )
       }
     }
   }
-  yield* Fiber.awaitAll(allUpdates)
+  yield* FiberSet.awaitEmpty(fibers)
 
-  // Pass 2: collect new transactions and import them
-  for (const { transactions, actualAccountId } of results) {
-    const { imported: alreadyImported } = allAlreadyImported.find(
-      (r) => r.actualAccountId === actualAccountId,
-    )!
-    let toImport: typeof transactions = []
-    for (const transaction of transactions) {
-      if (options.clearedOnly && !transaction.cleared) {
-        continue
-      }
-
-      const existing = alreadyImported.get(transaction.imported_id)
-      if (!existing) {
-        toImport.push(transaction)
-      }
-    }
-    yield* actual.use((_) => _.importTransactions(actualAccountId, toImport))
+  for (const [actualAccountId, transactions] of newTransactions) {
+    yield* FiberSet.run(
+      fibers,
+      actual.use((_) => _.importTransactions(actualAccountId, transactions)),
+    )
   }
-})
+  yield* FiberSet.awaitEmpty(fibers)
+}, Effect.scoped)
 
 const makeImportId = () => {
   const counters = new Map<string, number>()


### PR DESCRIPTION
When syncing shared Up Bank accounts (2UP), Forward/Cover transfers that were initially imported without a transfer payee (because the target account was not in scope) are now corrected to use the proper transfer payee before new transactions are imported. This prevents Actual Budget from auto-creating a duplicate counterpart transaction. 