### PR TITLE
Use created at date instead of settled for transaction date

### DIFF
--- a/.changeset/fix-up-use-created-at-date.md
+++ b/.changeset/fix-up-use-created-at-date.md
@@ -3,7 +3,3 @@
 ---
 
 fix(up): use transaction creation date instead of settlement date
-
-Up Bank transactions are now imported using `createdAt` (when the purchase
-was made) rather than `settledAt` (when it cleared), matching the date
-shown in the Up app.

--- a/.changeset/fix-up-use-created-at-date.md
+++ b/.changeset/fix-up-use-created-at-date.md
@@ -1,0 +1,9 @@
+---
+"@tim-smart/actualbudget-sync": patch
+---
+
+fix(up): use transaction creation date instead of settlement date
+
+Up Bank transactions are now imported using `createdAt` (when the purchase
+was made) rather than `settledAt` (when it cleared), matching the date
+shown in the Up app.

--- a/src/Bank/Up.ts
+++ b/src/Bank/Up.ts
@@ -160,7 +160,7 @@ class Transaction extends Schema.Class<Transaction>("Transaction")({
   }),
 }) {
   accountTransactions(): NonEmptyReadonlyArray<AccountTransaction> {
-    const dateTime = this.attributes.settledAt ?? this.attributes.createdAt
+    const dateTime = this.attributes.createdAt
     const cleared = this.attributes.status === "SETTLED"
     const amount = moneyToBigDecimal(this.attributes.amount)
     const description = this.attributes.description


### PR DESCRIPTION
Up Bank transactions are now imported using `createdAt` (when the purchase was made) rather than `settledAt` (when it cleared). This maybe based on personal preference, but the Up app maintains 'createdAt' as the transaction date in the UI, so this PR makes transaction match the date shown in the Up app. This is valuable for reconciliation as actual will match record ordering of the Up app UI. This could be worth making configurable in the future.
